### PR TITLE
Added a command for users to query all enchantment books sold by villagers in every biome.

### DIFF
--- a/lang/tw.json
+++ b/lang/tw.json
@@ -112,6 +112,7 @@
 	"faq.name.slot": "&faq.name.slots",
 	"faq.name.slots": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/b2/Items_slot_number.png",
 	"faq.name.standsvsclouds": "注意：自1.17先行版21w15a後，藥水雲的虛擬實體功能已被標記取代\nhttps://www.youtube.com/watch?v=RKXzWGQfIcg",
+	"faq.name.villagers":"https://media.discordapp.net/attachments/838398000866131992/1137308261104762951/1.20.2_villager_enchantments.png?width=1440&height=371",
 	"dtp.begin": "資料包功能: `",
 	"dtp.end": "`",
 	"dtp.fail": "無效的資料包功能，請嘗試使用</dtp:1102681768701722802>查看所有資料包功能。",

--- a/src/main/java/cartoland/commands/ICommand.java
+++ b/src/main/java/cartoland/commands/ICommand.java
@@ -28,6 +28,7 @@ public interface ICommand
 	String YOUTUBER = "youtuber";
 	String INTRODUCE = "introduce";
 	String BIRTHDAY = "birthday";
+	String VILLAGER = "villager";//Added by Champsing
 	String MEGUMIN = "megumin";
 	String SHUTDOWN = "shutdown";
 	String RELOAD = "reload";

--- a/src/main/java/cartoland/commands/ICommand.java
+++ b/src/main/java/cartoland/commands/ICommand.java
@@ -28,7 +28,7 @@ public interface ICommand
 	String YOUTUBER = "youtuber";
 	String INTRODUCE = "introduce";
 	String BIRTHDAY = "birthday";
-	String VILLAGER = "villager";//Added by Champsing
+	String VILLAGERS = "villagers";//Added by Champsing
 	String MEGUMIN = "megumin";
 	String SHUTDOWN = "shutdown";
 	String RELOAD = "reload";

--- a/src/main/java/cartoland/events/CommandUsage.java
+++ b/src/main/java/cartoland/events/CommandUsage.java
@@ -89,6 +89,10 @@ public class CommandUsage extends ListenerAdapter
 		//quote
 		commands.put(QUOTE, new QuoteCommand());
 
+		//villager //Added by Champsing
+		commands.put(VILLAGER, event -> event.reply("https://media.discordapp.net/attachments/838398000866131992/1137308261104762951/1.20.2_villager_enchantments.png?width=1440&height=371").queue();)
+
+
 		//youtuber
 		commands.put(YOUTUBER, event -> event.reply("https://www.youtube.com/" + event.getOption("youtuber_name", CommonFunctions.getAsString)).queue());
 

--- a/src/main/java/cartoland/messages/BotCanTalkChannelMessage.java
+++ b/src/main/java/cartoland/messages/BotCanTalkChannelMessage.java
@@ -32,6 +32,7 @@ public class BotCanTalkChannelMessage implements IMessage
 		"爹，您好呀。",
 		"聽候您差遣。",
 		"父親，無論您需要什麼幫助，我都會全力以赴！" //由 brick-bk 新增
+		"父親，您辛苦了，工作忙碌之餘，也請您別忘了多休息保護眼睛！"//Add by Champsing
 	};
 	private final String[] replyMegaMention =
 	{
@@ -40,6 +41,11 @@ public class BotCanTalkChannelMessage implements IMessage
 		"陛下今日可好？",
 		"願陛下萬壽無疆，國泰民安，天下太平。", //由 brick-bk 新增
 		"祝陛下萬歲，萬歲，萬萬歲！" //由 brick-bk 新增
+		//Add by Champsing
+		"微臣向皇上請安",
+		"皇上龍體安康",
+		"微臣參見陛下",
+		"皇上威震四海、聲赫五洲",
 	};
 	private final String[] replyMention =
 	{
@@ -68,7 +74,10 @@ public class BotCanTalkChannelMessage implements IMessage
 		"https://imgur.com/xxZVQvB", //你到別的地方去耍笨好不好
 		"小米格們也都別忘了Pick Me!\n在GitHub 點個星星 按個 讚。",
 		"如果大家喜歡這種機器人的話，別忘了點擊GitHub上面那個，大大～的星星！讓我知道。",
-		"你再tag我啊，再tag啊，沒被禁言過是不是？" //由 brick-bk 新增，經 Alex Cai 大幅修改
+		"你再tag我啊，再tag啊，沒被禁言過是不是？", //由 brick-bk 新增，經 Alex Cai 大幅修改
+		"胡不遄死？"//你怎麼不去死一死？　Added by Champsing
+		"豎子，不足與謀。"//死小孩，沒話跟你講。 Added by Champsing
+		"謹祈爾家無後也。" //祝福你家斷子絕孫。 Added by Champsing
 	};
 	private final String[] megumin =
 	{
@@ -186,7 +195,8 @@ public class BotCanTalkChannelMessage implements IMessage
 
 		if (rawMessage.contains("惠惠") || (rawMessageLength >= 7 && meguminRegex.matcher(rawMessage).matches()) || rawMessage.contains("めぐみん"))
 			channel.sendMessage(Algorithm.randomElement(megumin)).queue();
-
+		if (rawMessage.contains("鬼島交通"))//Added by Champsing
+			channel.sendMessage("https://memeprod.sgp1.digitaloceanspaces.com/user-wtf/1651071890313.jpg").queue();
 		if (rawMessage.contains("聰明"))
 			channel.sendMessage("https://tenor.com/view/galaxy-brain-meme-gif-25947987").queue();
 		if (rawMessage.contains("賺爛"))

--- a/src/main/java/cartoland/utilities/AddCommands.java
+++ b/src/main/java/cartoland/utilities/AddCommands.java
@@ -240,7 +240,7 @@ public final class AddCommands
 				.setDescriptionLocalization(JAPANESE, "最高のアニメの女の子"),
 		
 		//Added by Champsing
-		Commands.slash(VILLAGER, "Check out all enchantment books sold by villagers in every biome")
+		Commands.slash(VILLAGERS, "Check out all enchantment books sold by villagers in every biome")
 		.setDescriptionLocalization(CHINESE_TAIWAN, "查看每種生態域的村民賣的附魔書")
 		.setDescriptionLocalization(CHINESE_CHINA, "查看每种生态域的村民买的附魔书")
 		.setDescriptionLocalization(JAPANESE, "色んなバイオームの村人が売れる全てのエンチャントの本を見る"),	
@@ -582,22 +582,22 @@ final class Faq
 
 	static
 	{
-		faqDescriptions.put(CHINESE_TAIWAN, "獲得地圖製作的協助");
-		faqDescriptions.put(CHINESE_CHINA, "获得地图制作的协助");
+		faqDescriptions.put(CHINESE_TAIWAN, "獲得地圖製作或遊戲資訊的協助");
+		faqDescriptions.put(CHINESE_CHINA, "获得地图制作或游戏资讯的协助");
 	}
 
 	private static final OptionData faqOption =
-			new OptionData(OptionType.STRING, "faq_name", "A question about map making.", false, true)
+			new OptionData(OptionType.STRING, "faq_name", "A question about map making or game information.", false, true)
 					.setNameLocalization(CHINESE_TAIWAN, "問題")
 					.setNameLocalization(CHINESE_CHINA, "问题")
-					.setDescriptionLocalization(CHINESE_TAIWAN, "地圖製作的問題")
-					.setDescriptionLocalization(CHINESE_CHINA, "地图制作的问题");
+					.setDescriptionLocalization(CHINESE_TAIWAN, "地圖製作或遊戲資訊的問題")
+					.setDescriptionLocalization(CHINESE_CHINA, "地图制作或游戏资讯的问题");
 
-	static final SlashCommandData faq = Commands.slash(FAQ, "Find answers to map making questions")
+	static final SlashCommandData faq = Commands.slash(FAQ, "Find answers to map making or game information questions")
 			.setDescriptionLocalizations(faqDescriptions)
 			.addOptions(faqOption);
 
-	static final SlashCommandData question = Commands.slash(QUESTION, "Find answers to map making questions")
+	static final SlashCommandData question = Commands.slash(QUESTION, "Find answers to map making or game information questions")
 			.setDescriptionLocalizations(faqDescriptions)
 			.addOptions(faqOption);
 }

--- a/src/main/java/cartoland/utilities/AddCommands.java
+++ b/src/main/java/cartoland/utilities/AddCommands.java
@@ -238,6 +238,13 @@ public final class AddCommands
 				.setDescriptionLocalization(CHINESE_TAIWAN, "最讚的動漫女孩")
 				.setDescriptionLocalization(CHINESE_CHINA, "最赞的动漫女孩")
 				.setDescriptionLocalization(JAPANESE, "最高のアニメの女の子"),
+		
+		//Added by Champsing
+		Commands.slash(VILLAGER, "Check out all enchantment books sold by villagers in every biome")
+		.setDescriptionLocalization(CHINESE_TAIWAN, "查看每種生態域的村民賣的附魔書")
+		.setDescriptionLocalization(CHINESE_CHINA, "查看每种生态域的村民买的附魔书")
+		.setDescriptionLocalization(JAPANESE, "色んなバイオームの村人が売れる全てのエンチャントの本を見る"),	
+		
 
 		Commands.slash(SHUTDOWN, "Use this to shut down the bot")
 				.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.ADMINISTRATOR)),


### PR DESCRIPTION
這項貢獻包含了一個新指令`/villager`。
使用這個指令時，機器人會回覆一張圖片，內容為不同生態域的村民與其對應銷售的附魔書整理而成的表格。
特別針對圖書管理員。

This contribution includes a new command `/villager`.
It will reply a image of a table representing which kinds of enchantment books are sold by villagers in the corresponding biome.
Especially Librarians.

このコントリビューションは一つの新しいコマンド`/villager`が含まれています。
このコマンドを使用すると、ボットは異なるバイオームの村人とそれに対応する販売のエンチャントの本が整理された表の画像を返信します。
特に司書でございます。