### PR TITLE
Refactor forwarding private messages function with forwardTo() provided in JDA 5.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.1.0</version>
+            <version>5.1.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <!-- https://github.com/stleary/JSON-java -->

--- a/src/main/java/cartoland/messages/PrivateMessage.java
+++ b/src/main/java/cartoland/messages/PrivateMessage.java
@@ -6,15 +6,7 @@ import cartoland.utilities.ObjectAndString;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
-import net.dv8tion.jda.api.entities.sticker.StickerItem;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.utils.FileUpload;
-import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
-
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 /**
  * {@code PrivateMessage} is a listener that triggers when a user types anything in the direct message to the bot. This
@@ -45,48 +37,8 @@ public class PrivateMessage implements IMessage
 			return;
 		}
 
-		MessageCreateBuilder messageBuilder = MessageCreateBuilder.fromMessage(message); //訊息本文
-		List<Message.Attachment> attachments = message.getAttachments(); //訊息附件
-		List<StickerItem> stickers = message.getStickers();
-		if (!attachments.isEmpty() || !stickers.isEmpty()) //有附件或貼圖
-		{
-			List<FileUpload> files = new ArrayList<>(); //要上傳的檔案
+		message.forwardTo((TextChannel) channelAndString.object());
 
-			for (Message.Attachment attachment : attachments) //附件
-			{
-				files.add(FileUpload.fromStreamSupplier(attachment.getFileName(), () ->
-				{
-					try
-					{
-						return attachment.getProxy().download().get();
-					}
-					catch (InterruptedException | ExecutionException e)
-					{
-						return InputStream.nullInputStream();
-					}
-				}));
-			}
-
-			for (StickerItem sticker : stickers) //貼圖
-			{
-				files.add(FileUpload.fromStreamSupplier(sticker.getName() + '.' + sticker.getFormatType().getExtension(), () ->
-				{
-					try
-					{
-						return sticker.getIcon().download().get();
-					}
-					catch (InterruptedException | ExecutionException e)
-					{
-						return InputStream.nullInputStream();
-					}
-				}));
-			}
-
-			messageBuilder.addFiles(files);
-		}
-
-		((TextChannel) channelAndString.object()).sendMessage(messageBuilder.build()) //私訊轉到地下聊天室
-				.queue(undergroundMessage -> AnonymousHandle.addConnection(message.getIdLong(), undergroundMessage.getIdLong()));
 		FileHandle.dmLog(author.getName(), ' ', author.getId(), ' ', message.getContentRaw());
 	}
 }


### PR DESCRIPTION
This PR upgraded JDA version to `5.1.2` and deleted a bunch of special handlings about input message types in `PrivateMessage` listener. It simply uses `forwardTo()` to forward messages users send to their private chats with the Bot.