### PR TITLE
New Feature on Replying Mentions: Add Bot Messages to Reply When the Mention Is Notification-suppressed

### DIFF
--- a/src/main/java/cartoland/messages/BotCanTalkChannelMessage.java
+++ b/src/main/java/cartoland/messages/BotCanTalkChannelMessage.java
@@ -76,6 +76,12 @@ public class BotCanTalkChannelMessage implements IMessage
 		"你再tag我啊，再tag啊，沒被禁言過是不是？", //由 brick-bk 新增，經 Alex Cai 大幅修改
 		"豎子，不足與謀。"//死小孩，沒話跟你講。 Added by Champsing
 	};
+	private final String[] replySilentMention =
+	{
+		"你以為加了`@silent`我就不知道了嗎？",
+		"@silent <:ping:" + IDs.PING_EMOJI_ID + '>',
+		"做壞事是不用打廣告的，因其自當傳千里。"
+	};
 	private final String[] megumin =
 	{
 		"☆めぐみん大好き！☆",
@@ -132,7 +138,9 @@ public class BotCanTalkChannelMessage implements IMessage
 			{
 				long channelID = channel.getIdLong();
 				if (channelID == IDs.BOT_CHANNEL_ID || channelID == IDs.UNDERGROUND_CHANNEL_ID) //如果頻道在機器人或地下 就正常地回傳replyMention
-					message.reply(Algorithm.randomElement(replyMention)).mentionRepliedUser(false).queue();
+					if (message.isSuppressedNotifications()) //如果是@silent訊息
+						message.reply(Algorithm.randomElement(replySilentMention)).mentionRepliedUser(false).queue();
+					else message.reply(Algorithm.randomElement(replyMention)).mentionRepliedUser(false).queue();
 				else //在其他地方ping就固定加一個ping的emoji
 					message.addReaction(Emoji.fromCustom("ping", IDs.PING_EMOJI_ID, false)).queue();
 			}


### PR DESCRIPTION
This PR contains 1 commit which adds a new String[] containing messages for the Bot to reply when mentioned with `@silent`, the tag used to suppress the desktop notification of a message, and an if-else statement to query if the message was sent with its notification suppressed.
If so, the Bot will reply a random sentence in the newly-added String[] `replySilentMention` to the message author rather than in `replyMention`, used when it is mentioned normally.